### PR TITLE
ovpn-dco: fix build failure in kernel 6.6

### DIFF
--- a/drivers/net/ovpn-dco/udp.c
+++ b/drivers/net/ovpn-dco/udp.c
@@ -176,9 +176,15 @@ static int ovpn_udp4_output(struct ovpn_struct *ovpn, struct ovpn_bind *bind,
 	dst_cache_set_ip4(cache, &rt->dst, fl.saddr);
 
 transmit:
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
+	udp_tunnel_xmit_skb(rt, sk, skb, fl.saddr, fl.daddr, 0,
+			    ip4_dst_hoplimit(&rt->dst), 0, fl.fl4_sport,
+			    fl.fl4_dport, false, sk->sk_no_check_tx);
+#else
 	udp_tunnel_xmit_skb(rt, sk, skb, fl.saddr, fl.daddr, 0,
 			    ip4_dst_hoplimit(&rt->dst), 0, fl.fl4_sport,
 			    fl.fl4_dport, false, sk->sk_no_check_tx, 0);
+#endif
 	ret = 0;
 err:
 	local_bh_enable();
@@ -227,9 +233,15 @@ static int ovpn_udp6_output(struct ovpn_struct *ovpn, struct ovpn_bind *bind,
 	dst_cache_set_ip6(cache, dst, &fl.saddr);
 
 transmit:
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
+	udp_tunnel6_xmit_skb(dst, sk, skb, skb->dev, &fl.saddr, &fl.daddr, 0,
+			     ip6_dst_hoplimit(dst), 0, fl.fl6_sport,
+			     fl.fl6_dport, udp_get_no_check6_tx(sk));
+#else
 	udp_tunnel6_xmit_skb(dst, sk, skb, skb->dev, &fl.saddr, &fl.daddr, 0,
 			     ip6_dst_hoplimit(dst), 0, fl.fl6_sport,
 			     fl.fl6_dport, udp_get_no_check6_tx(sk), 0);
+#endif
 	ret = 0;
 err:
 	local_bh_enable();

--- a/linux-compat.h
+++ b/linux-compat.h
@@ -40,39 +40,6 @@
 #define SUSE_PRODUCT(pr, v, pl, aux) 1
 #endif
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
-
-#include <net/udp_tunnel.h>
-
-static inline void ovpn_udp_tunnel_xmit_skb(struct rtable *rt, struct sock *sk,
-					    struct sk_buff *skb, __be32 src,
-					    __be32 dst, __u8 tos, __u8 ttl,
-					    __be16 df, __be16 src_port,
-					    __be16 dst_port, bool xnet,
-					    bool nocheck, u16 ipcb_flags)
-{
-	udp_tunnel_xmit_skb(rt, sk, skb, src, dst, tos, ttl, df, src_port,
-			    dst_port, xnet, nocheck);
-}
-#define udp_tunnel_xmit_skb ovpn_udp_tunnel_xmit_skb
-
-static inline void ovpn_udp_tunnel6_xmit_skb(struct dst_entry *dst,
-					     struct sock *sk,
-					     struct sk_buff *skb,
-					     struct net_device *dev,
-					     const struct in6_addr *saddr,
-					     const struct in6_addr *daddr,
-					     __u8 prio, __u8 ttl, __be32 label,
-					     __be16 src_port, __be16 dst_port,
-					     bool nocheck, u16 ip6cb_flags)
-{
-	udp_tunnel6_xmit_skb(dst, sk, skb, dev, saddr, daddr, prio, ttl, label,
-			     src_port, dst_port, nocheck);
-}
-#define udp_tunnel6_xmit_skb ovpn_udp_tunnel6_xmit_skb
-
-#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(6, 17, 0) */
-
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 16, 0)
 
 #ifndef UDP_ENCAP_OVPNINUDP


### PR DESCRIPTION
fix error: passing argument 5 and 6 of 'udp_tunnel6_xmit_skb' discards 'const' qualifier from pointer target type
error log:
2025-09-27T16:50:29.7779407Z In file included from <command-line>:
2025-09-27T16:50:29.7780878Z /builder/build_dir/target-aarch64_generic_musl/linux-layerscape_armv8_64b/ovpn-dco-0.2.20250922/linux-compat.h: In function 'ovpn_udp_tunnel6_xmit_skb':
2025-09-27T16:50:29.7783352Z /builder/build_dir/target-aarch64_generic_musl/linux-layerscape_armv8_64b/ovpn-dco-0.2.20250922/linux-compat.h:69:49: error: passing argument 5 of 'udp_tunnel6_xmit_skb' discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
2025-09-27T16:50:29.7785318Z    69 |         udp_tunnel6_xmit_skb(dst, sk, skb, dev, saddr, daddr, prio, ttl, label,
2025-09-27T16:50:29.7785974Z       |                                                 ^~~~~
2025-09-27T16:50:29.7787090Z In file included from /builder/build_dir/target-aarch64_generic_musl/linux-layerscape_armv8_64b/ovpn-dco-0.2.20250922/linux-compat.h:45:
2025-09-27T16:50:29.7788840Z ./include/net/udp_tunnel.h:157:67: note: expected 'struct in6_addr *' but argument is of type 'const struct in6_addr *'
2025-09-27T16:50:29.7790061Z   157 |                          struct net_device *dev, struct in6_addr *saddr,
2025-09-27T16:50:29.7790633Z       |                                                  ~~~~~~~~~~~~~~~~~^~~~~
2025-09-27T16:50:29.7792417Z /builder/build_dir/target-aarch64_generic_musl/linux-layerscape_armv8_64b/ovpn-dco-0.2.20250922/linux-compat.h:69:56: error: passing argument 6 of 'udp_tunnel6_xmit_skb' discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
2025-09-27T16:50:29.7794289Z    69 |         udp_tunnel6_xmit_skb(dst, sk, skb, dev, saddr, daddr, prio, ttl, label,
2025-09-27T16:50:29.7794899Z       |                                                        ^~~~~
2025-09-27T16:50:29.7795763Z ./include/net/udp_tunnel.h:158:43: note: expected 'struct in6_addr *' but argument is of type 'const struct in6_addr *'
2025-09-27T16:50:29.7796680Z   158 |                          struct in6_addr *daddr,
2025-09-27T16:50:29.7797153Z       |                          ~~~~~~~~~~~~~~~~~^~~~~
2025-09-27T16:50:29.8511989Z cc1: all warnings being treated as errors
2025-09-27T16:50:29.8548254Z make[5]: *** [scripts/Makefile.build:243: /builder/build_dir/target-aarch64_generic_musl/linux-layerscape_armv8_64b/ovpn-dco-0.2.20250922/drivers/net/ovpn-dco/main.o] Error 1
2025-09-27T16:50:29.8551417Z make[4]: *** [/builder/build_dir/target-aarch64_generic_musl/linux-layerscape_armv8_64b/linux-6.6.107/Makefile:1924: /builder/build_dir/target-aarch64_generic_musl/linux-layerscape_armv8_64b/ovpn-dco-0.2.20250922/drivers/net/ovpn-dco] Error 2
2025-09-27T16:50:29.8553257Z make[3]: *** [Makefile:234: __sub-make] Error 2
2025-09-27T16:50:29.8554193Z make[3]: Leaving directory '/builder/build_dir/target-aarch64_generic_musl/linux-layerscape_armv8_64b/linux-6.6.107'
2025-09-27T16:50:29.8556095Z make[2]: *** [Makefile:68: /builder/build_dir/target-aarch64_generic_musl/linux-layerscape_armv8_64b/ovpn-dco-0.2.20250922/.built] Error 2