### PR TITLE
ci: add virtme-ng build matrix

### DIFF
--- a/.github/workflows/vng-build.yml
+++ b/.github/workflows/vng-build.yml
@@ -1,0 +1,25 @@
+---
+name: virtme-ng build
+
+"on":
+  workflow_dispatch:
+  schedule:
+    - cron: "17 7 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  vng-tests:
+    uses: mandelbitdev/kmod-ci/.github/workflows/out-of-tree-vng.yml@main
+    with:
+      ci-repository: mandelbitdev/kmod-ci
+      cache-prefix: ovpn-dco
+      guest-script: ci/run-build.sh
+      distros: >-
+        ["debian-12", "debian-13",
+        "ubuntu-22.04", "ubuntu-24.04", "ubuntu-26.04",
+        "rhel-8", "rhel-9", "rhel-10"]
+    secrets:
+      RHEL_ORG_ID: ${{ secrets.RHEL_ORG_ID }}
+      RHEL_ACTIVATION_KEY: ${{ secrets.RHEL_ACTIVATION_KEY }}

--- a/ci/run-build.sh
+++ b/ci/run-build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+
+set -euo pipefail
+
+cd /repo
+
+echo "Guest OS:"
+cat /etc/os-release
+echo
+echo "Guest kernel:"
+uname -a
+echo
+echo "Kernel build directory:"
+readlink -f "/lib/modules/$(uname -r)/build"
+
+# The repo is copied from the host, so root in the guest sees different
+# ownership and Git may reject it as a dubious worktree.
+git config --global --add safe.directory /repo
+
+make -j"$(nproc)"
+make install
+modprobe ovpn-dco-v2
+rmmod ovpn-dco-v2


### PR DESCRIPTION
Add a GitHub Actions workflow that reuses the shared kmod-ci virtme-ng matrix to build ovpn-dco-v2 across supported distro kernels.