### PR TITLE
ci: stop passing ci-repository to kmod-ci

### DIFF
--- a/.github/workflows/vng-build.yml
+++ b/.github/workflows/vng-build.yml
@@ -13,7 +13,6 @@ jobs:
   vng-tests:
     uses: mandelbitdev/kmod-ci/.github/workflows/out-of-tree-vng.yml@main
     with:
-      ci-repository: mandelbitdev/kmod-ci
       cache-prefix: ovpn-dco
       guest-script: ci/run-build.sh
       distros: >-


### PR DESCRIPTION
The CI has deprecated ci-repository and ci-ref since those can be inferred from the "uses:" tag.

Remove the deprecated input from the workflow.