### PR TITLE
ci: add manual arm64 build coverage

### DIFF
--- a/.github/workflows/vng-arm64-build.yml
+++ b/.github/workflows/vng-arm64-build.yml
@@ -1,0 +1,23 @@
+---
+name: virtme-ng arm64 build
+
+"on":
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  vng-arm64-build:
+    uses: mandelbitdev/kmod-ci/.github/workflows/out-of-tree-vng.yml@main
+    with:
+      arch: arm64
+      cache-prefix: ovpn-dco-arm64
+      guest-script: ci/run-build.sh
+      distros: >-
+        ["debian-12", "debian-13",
+        "ubuntu-22.04", "ubuntu-24.04", "ubuntu-26.04",
+        "rhel-8", "rhel-9", "rhel-10"]
+    secrets:
+      RHEL_ORG_ID: ${{ secrets.RHEL_ORG_ID }}
+      RHEL_ACTIVATION_KEY: ${{ secrets.RHEL_ACTIVATION_KEY }}

--- a/.github/workflows/vng-x86_64-build.yml
+++ b/.github/workflows/vng-x86_64-build.yml
@@ -1,5 +1,5 @@
 ---
-name: virtme-ng build
+name: virtme-ng x86_64 build
 
 "on":
   workflow_dispatch:


### PR DESCRIPTION
Add a workflow_dispatch-only arm64 virtme-ng workflow that builds the module and verifies that it can be loaded and unloaded on arm64 targets.

GitHub-hosted arm64 runners do not expose KVM, so the jobs run through QEMU emulation and are not reliable enough for nightly selftest coverage. Keep the scheduled matrix on x86_64 and use arm64 as explicit build/load coverage for now.